### PR TITLE
缺少gcc编译器修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=builder_node /web/ui  /anylink/server/ui
 
 #TODO 本地打包时使用镜像
 #RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories
-RUN apk add --no-cache git
+RUN apk add --no-cache git gcc
 RUN cd /anylink/server;go build -o anylink -ldflags "-X main.CommitId=$(git rev-parse HEAD)" \
     && /anylink/server/anylink tool -v
 


### PR DESCRIPTION
修正编译Docker镜像时 无gcc编译器报错的问题
cgo: exec gcc: exec: "gcc": executable file not found in $PATH
The command '/bin/sh -c cd /anylink/server;go build -o anylink -ldflags "-X main.CommitId=$(git rev-parse HEAD)"     && /anylink/server/anylink tool -v' returned a non-zero code: 2