### PR TITLE
当只有一个可用的用户组时，客户端不显示用户组选项

### DIFF
--- a/server/dbdata/group.go
+++ b/server/dbdata/group.go
@@ -58,6 +58,22 @@ func GetGroupNames() []string {
 	return names
 }
 
+func GetAvailableGroups() []string {
+	var datas []Group
+	err := Find(&datas, 0, 0)
+	if err != nil {
+		base.Error(err)
+		return nil
+	}
+	var names []string
+	for _, v := range datas {
+		if v.Status == 1 {
+			names = append(names, v.Name)
+		}
+	}
+	return names
+}
+
 func SetGroup(g *Group) error {
 	var err error
 	if g.Name == "" {

--- a/server/dbdata/user.go
+++ b/server/dbdata/user.go
@@ -67,7 +67,7 @@ func SetUser(v *User) error {
 }
 
 // 验证用户登陆信息
-func CheckUser(name, pwd, group string) error {
+func CheckUser(name, pwd string, group *string) error {
 	// TODO 严重问题
 	// return nil
 
@@ -81,7 +81,16 @@ func CheckUser(name, pwd, group string) error {
 		return fmt.Errorf("%s %s", name, "用户名错误")
 	}
 	// 判断用户组信息
-	if !utils.InArrStr(v.Groups, group) {
+	// 当只有一个可用的用户组时，客户端不显示用户组选项，默认使用该用户唯一可用的组
+	if *group == "" {
+		Groups := GetAvailableGroups()
+		for _, g := range v.Groups {
+			if utils.InArrStr(Groups, g) {
+				*group = g
+				break
+			}
+		}
+	} else if !utils.InArrStr(v.Groups, *group) {
 		return fmt.Errorf("%s %s", name, "用户组错误")
 	}
 	groupData := &Group{}

--- a/server/dbdata/user_test.go
+++ b/server/dbdata/user_test.go
@@ -32,12 +32,12 @@ func TestCheckUser(t *testing.T) {
 	// 验证 PinCode + OtpSecret
 	totp := gotp.NewDefaultTOTP(u.OtpSecret)
 	secret := totp.Now()
-	err = CheckUser("aaa", u.PinCode+secret, group)
+	err = CheckUser("aaa", u.PinCode+secret, &group)
 	ast.Nil(err)
 
 	// 单独验证密码
 	u.DisableOtp = true
 	_ = SetUser(&u)
-	err = CheckUser("aaa", u.PinCode, group)
+	err = CheckUser("aaa", u.PinCode, &group)
 	ast.Nil(err)
 }

--- a/server/handler/link_auth.go
+++ b/server/handler/link_auth.go
@@ -150,13 +150,13 @@ var auth_request = `<?xml version="1.0" encoding="UTF-8"?>
         <form>
             <input type="text" name="username" label="Username:"></input>
             <input type="password" name="password" label="Password:"></input>
-			{{if gt (len .Groups) 1}}
+	    {{if gt (len .Groups) 1}}
             <select name="group_list" label="GROUP:">
                 {{range $v := .Groups}}
                 <option {{if eq $v $.Group}} selected="true"{{end}}>{{$v}}</option>
                 {{end}}
             </select>
-			{{end}}
+	    {{end}}
         </form>
     </auth>
 </config-auth>

--- a/server/handler/link_auth.go
+++ b/server/handler/link_auth.go
@@ -55,7 +55,7 @@ func LinkAuth(w http.ResponseWriter, r *http.Request) {
 
 	if cr.Type == "init" {
 		w.WriteHeader(http.StatusOK)
-		data := RequestData{Group: cr.GroupSelect, Groups: dbdata.GetGroupNames()}
+		data := RequestData{Group: cr.GroupSelect, Groups: dbdata.GetAvailableGroups()}
 		tplRequest(tpl_request, w, data)
 		return
 	}
@@ -67,11 +67,11 @@ func LinkAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO 用户密码校验
-	err = dbdata.CheckUser(cr.Auth.Username, cr.Auth.Password, cr.GroupSelect)
+	err = dbdata.CheckUser(cr.Auth.Username, cr.Auth.Password, &cr.GroupSelect)
 	if err != nil {
 		base.Warn(err)
 		w.WriteHeader(http.StatusOK)
-		data := RequestData{Group: cr.GroupSelect, Groups: dbdata.GetGroupNames(), Error: "用户名或密码错误"}
+		data := RequestData{Group: cr.GroupSelect, Groups: dbdata.GetAvailableGroups(), Error: err.Error()}
 		tplRequest(tpl_request, w, data)
 		return
 	}
@@ -150,11 +150,13 @@ var auth_request = `<?xml version="1.0" encoding="UTF-8"?>
         <form>
             <input type="text" name="username" label="Username:"></input>
             <input type="password" name="password" label="Password:"></input>
+			{{if gt (len .Groups) 1}}
             <select name="group_list" label="GROUP:">
                 {{range $v := .Groups}}
                 <option {{if eq $v $.Group}} selected="true"{{end}}>{{$v}}</option>
                 {{end}}
             </select>
+			{{end}}
         </form>
     </auth>
 </config-auth>


### PR DESCRIPTION
客户端总是让选择用户组非常烦人，也没有必要，当前更改实现
1、当只有一个可用的用户组时，客户端不显示用户组选项（多个用户组时不受影响）
2、之前登陆时无论什么类型错误，客户端都显示 `用户名或密码错误`，现在根据情况分别提示用户名、密码、用户组错误