### PR TITLE
优化弹窗里标签页的用户体验

### DIFF
--- a/server/dbdata/userauth_ldap.go
+++ b/server/dbdata/userauth_ldap.go
@@ -45,7 +45,7 @@ func (auth AuthLdap) checkData(authData map[string]interface{}) error {
 		return errors.New("LDAP的用户查询密码不能为空")
 	}
 	if auth.BaseDn == "" || !ValidateDN(auth.BaseDn) {
-		return errors.New("LDAP的BaseName填写有误")
+		return errors.New("LDAP的BaseDN填写有误")
 	}
 	if auth.SearchAttr == "" {
 		return errors.New("LDAP的搜索属性不能为空")
@@ -117,7 +117,6 @@ func (auth AuthLdap) checkUser(name, pwd string, g *Group) error {
 		return fmt.Errorf("LDAP发现 %s 用户，存在多个账号", name)
 	}
 	userDN := sr.Entries[0].DN
-	fmt.Println(userDN)
 	err = l.Bind(userDN, pwd)
 	if err != nil {
 		return fmt.Errorf("%s LDAP 登入失败，请检查登入的账号或密码 %s", name, err.Error())

--- a/server/dbdata/userauth_ldap.go
+++ b/server/dbdata/userauth_ldap.go
@@ -74,10 +74,11 @@ func (auth AuthLdap) checkUser(name, pwd string, g *Group) error {
 		return fmt.Errorf("%s %s", name, "LDAP Unmarshal出现错误")
 	}
 	// 检测服务器和端口的可用性
-	_, err = net.DialTimeout("tcp", auth.Addr, 3*time.Second)
+	con, err := net.DialTimeout("tcp", auth.Addr, 3*time.Second)
 	if err != nil {
 		return fmt.Errorf("%s %s", name, "LDAP服务器连接异常, 请检测服务器和端口")
 	}
+	defer con.Close()
 	// 连接LDAP
 	l, err := ldap.Dial("tcp", auth.Addr)
 	if err != nil {

--- a/server/go.mod
+++ b/server/go.mod
@@ -4,6 +4,8 @@ go 1.16
 
 require (
 	github.com/StackExchange/wmi v1.2.1 // indirect
+	github.com/go-ldap/ldap v3.0.3+incompatible // indirect
+	github.com/go-ldap/ldap/v3 v3.4.3 // indirect
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/google/gopacket v1.1.19
@@ -22,9 +24,10 @@ require (
 	github.com/tklauser/go-sysconf v0.3.7 // indirect
 	github.com/xhit/go-simple-mail/v2 v2.10.0
 	github.com/xlzd/gotp v0.0.0-20181030022105-c8557ba2c119
-	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
-	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d
+	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
+	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
 	layeh.com/radius v0.0.0-20210819152912-ad72663a72ab
 	xorm.io/xorm v1.2.2
 )

--- a/web/src/pages/group/List.vue
+++ b/web/src/pages/group/List.vue
@@ -168,10 +168,11 @@
         title="用户组"
         :visible.sync="user_edit_dialog"
         width="750px"
+        @close='closeDialog'
         center>
 
       <el-form :model="ruleForm" :rules="rules" ref="ruleForm" label-width="100px" class="ruleForm">
-        <el-tabs v-model="activeTab">
+        <el-tabs v-model="activeTab" :before-leave="beforeTabLeave">
            <el-tab-pane label="通用" name="general">      
                 <el-form-item label="用户组ID" prop="id">
                 <el-input v-model="ruleForm.id" disabled></el-input>
@@ -359,7 +360,7 @@
             </el-tab-pane>
             <el-form-item>
             <el-button type="primary" @click="submitForm('ruleForm')">保存</el-button>
-            <el-button @click="disVisible">取消</el-button>
+            <el-button @click="closeDialog">取消</el-button>
             </el-form-item>
           </el-tabs>
         </el-form> 
@@ -473,10 +474,9 @@ export default {
         console.log(error);
       });
     },
-    handleEdit(row) {
+    handleEdit(row) {      
       !this.$refs['ruleForm'] || this.$refs['ruleForm'].resetFields();
-      console.log(row)
-      this.activeTab = "general"
+      console.log(row)      
       this.user_edit_dialog = true
       if (!row) {
         this.setAuthData(row)
@@ -561,6 +561,24 @@ export default {
     },
     authTypeChange() {
       this.$refs['ruleForm'].clearValidate();
+    },
+    beforeTabLeave() {
+      var isSwitch = true
+      if (! this.user_edit_dialog) {
+        return isSwitch;
+      }      
+      this.$refs['ruleForm'].validate((valid) => {
+        if (!valid) {
+          this.$message.error("错误：您有必填项没有填写。")
+          isSwitch = false;
+          return false;
+        }
+      });      
+      return isSwitch;
+    },
+    closeDialog() {
+      this.user_edit_dialog = false;
+      this.activeTab = "general";
     }
   },
 }

--- a/web/src/pages/user/Policy.vue
+++ b/web/src/pages/user/Policy.vue
@@ -136,10 +136,11 @@
         :visible.sync="user_edit_dialog"
         width="750px"
         top="50px"
+        @close='closeDialog'
         center>
 
       <el-form :model="ruleForm" :rules="rules" ref="ruleForm" label-width="100px" class="ruleForm">
-        <el-tabs v-model="activeTab">
+        <el-tabs v-model="activeTab" :before-leave="beforeTabLeave">
            <el-tab-pane label="通用" name="general">
                 <el-form-item label="ID" prop="id">
                 <el-input v-model="ruleForm.id" disabled></el-input>
@@ -283,7 +284,7 @@ export default {
         re_upper_limit : 0,        
       },
       rules: {
-        name: [
+        username: [
           {required: true, message: '请输入用户名', trigger: 'blur'},
           {max: 30, message: '长度小于 30 个字符', trigger: 'blur'}
         ],
@@ -398,7 +399,25 @@ export default {
       } else {
         this.$set(this.readMore, id, true);
       }
-    },    
+    },
+    beforeTabLeave() {
+      var isSwitch = true
+      if (! this.user_edit_dialog) {
+        return isSwitch;
+      }      
+      this.$refs['ruleForm'].validate((valid) => {
+        if (!valid) {
+          this.$message.error("错误：您有必填项没有填写。")
+          isSwitch = false;
+          return false;
+        }
+      });      
+      return isSwitch;
+    },
+    closeDialog() {
+      this.user_edit_dialog = false;
+      this.activeTab = "general";
+    },        
   },
 
 }


### PR DESCRIPTION
**问题：** 打开“添加弹窗”后，如果单击了“路由设置”、“权限控制”标签页，再按下“保存”按钮，你会发现页面没有反应....
**方案：** 当前标签页有必填项时，必须填写后，才能切换至其他标签页

<img width="668" alt="image" src="https://user-images.githubusercontent.com/3632406/177305931-9277464d-a1aa-48e7-8a3c-0203ae4ee989.png">

