### PR TITLE
修复access_proto字段导致无法启动的问题

### DIFF
--- a/server/dbdata/tables.go
+++ b/server/dbdata/tables.go
@@ -66,8 +66,8 @@ type AccessAudit struct {
 	SrcPort     uint16    `json:"src_port" xorm:"not null"`
 	Dst         string    `json:"dst" xorm:"varchar(60) not null"`
 	DstPort     uint16    `json:"dst_port" xorm:"not null"`
-	AccessProto uint8     `json:"access_proto" xorm:"not null"`      // 访问协议
-	Info        string    `json:"info" xorm:"varchar(255) not null"` // 详情
+	AccessProto uint8     `json:"access_proto" xorm:"not null default 0 Int(10)"` // 访问协议
+	Info        string    `json:"info" xorm:"varchar(255) not null"`              // 详情
 	CreatedAt   time.Time `json:"created_at" xorm:"DateTime"`
 }
 

--- a/server/dbdata/tables.go
+++ b/server/dbdata/tables.go
@@ -66,8 +66,8 @@ type AccessAudit struct {
 	SrcPort     uint16    `json:"src_port" xorm:"not null"`
 	Dst         string    `json:"dst" xorm:"varchar(60) not null"`
 	DstPort     uint16    `json:"dst_port" xorm:"not null"`
-	AccessProto uint8     `json:"access_proto" xorm:"not null default 0 Int(10)"` // 访问协议
-	Info        string    `json:"info" xorm:"varchar(255) not null"`              // 详情
+	AccessProto uint8     `json:"access_proto" xorm:"default 0"`                // 访问协议
+	Info        string    `json:"info" xorm:"varchar(255) not null default ''"` // 详情
 	CreatedAt   time.Time `json:"created_at" xorm:"DateTime"`
 }
 


### PR DESCRIPTION
**现状：** 使用sqlite数据库，如果升级dev后，会无法启动，报以下错误
```
[Fatal] Cannot add a NOT NULL column with default value NULL
```
**原因：** sqlite新增字段，需填写默认值；