### PR TITLE
增加default_domain配置参数

### DIFF
--- a/server/base/cfg.go
+++ b/server/base/cfg.go
@@ -67,6 +67,7 @@ type ServerConfig struct {
 	MobileKeepalive int    `json:"mobile_keepalive"`
 	MobileDpd       int    `json:"mobile_dpd"`
 	Mtu             int    `json:"mtu"`
+	DefaultDomain   string `json:"default_domain"`
 
 	SessionTimeout int `json:"session_timeout"` // in seconds
 	// AuthTimeout    int `json:"auth_timeout"`    // in seconds

--- a/server/base/config.go
+++ b/server/base/config.go
@@ -46,6 +46,7 @@ var configs = []config{
 	{Typ: cfgStr, Name: "ipv4_start", Usage: "IPV4开始地址", ValStr: "192.168.10.100"},
 	{Typ: cfgStr, Name: "ipv4_end", Usage: "IPV4结束", ValStr: "192.168.10.200"},
 	{Typ: cfgStr, Name: "default_group", Usage: "默认用户组", ValStr: "one"},
+	{Typ: cfgStr, Name: "default_domain", Usage: "要发布的默认域", ValStr: ""},
 
 	{Typ: cfgInt, Name: "ip_lease", Usage: "IP租期(秒)", ValInt: 1209600},
 	{Typ: cfgInt, Name: "max_client", Usage: "最大用户连接", ValInt: 100},

--- a/server/conf/server-sample.toml
+++ b/server/conf/server-sample.toml
@@ -64,6 +64,10 @@ mobile_dpd = 50
 #设置最大传输单元
 mtu = 1460
 
+# 要发布的默认域
+default_domain = "example.com"
+#default_domain = "example.com abc.example.com"
+
 #session过期时间，用于断线重连，0永不过期
 session_timeout = 3600
 auth_timeout = 0

--- a/server/handler/link_tunnel.go
+++ b/server/handler/link_tunnel.go
@@ -97,8 +97,11 @@ func LinkTunnel(w http.ResponseWriter, r *http.Request) {
 	HttpSetHeader(w, "X-CSTP-Address", cSess.IpAddr.String())             // 分配的ip地址
 	HttpSetHeader(w, "X-CSTP-Netmask", sessdata.IpPool.Ipv4Mask.String()) // 子网掩码
 	HttpSetHeader(w, "X-CSTP-Hostname", hn)                               // 机器名称
-	//HttpSetHeader(w, "X-CSTP-Default-Domain", cSess.LocalIp)
 	HttpSetHeader(w, "X-CSTP-Base-MTU", cstpBaseMtu)
+	// 要发布的默认域
+	if base.Cfg.DefaultDomain != "" {
+		HttpSetHeader(w, "X-CSTP-Default-Domain", base.Cfg.DefaultDomain)
+	}
 
 	// 设置用户策略
 	SetUserPolicy(sess.Username, cSess.Group)


### PR DESCRIPTION
**简介：** 要发布的默认域

**好处：** 当连上VPN后，可以直接通过“计算机名”远程连接公司的域控电脑，而非填写长串的“计算机名 + xxx.com”

