### PR TITLE
首页图表可查看用户组下的在线数、网络吞吐量

### DIFF
--- a/server/admin/api_group.go
+++ b/server/admin/api_group.go
@@ -47,6 +47,16 @@ func GroupNames(w http.ResponseWriter, r *http.Request) {
 	RespSucess(w, data)
 }
 
+func GroupNamesIds(w http.ResponseWriter, r *http.Request) {
+	var names = dbdata.GetGroupNamesIds()
+	data := map[string]interface{}{
+		"count":     len(names),
+		"page_size": 0,
+		"datas":     names,
+	}
+	RespSucess(w, data)
+}
+
 func GroupDetail(w http.ResponseWriter, r *http.Request) {
 	_ = r.ParseForm()
 	idS := r.FormValue("id")

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -62,6 +62,7 @@ func StartAdmin() {
 
 	r.HandleFunc("/group/list", GroupList)
 	r.HandleFunc("/group/names", GroupNames)
+	r.HandleFunc("/group/names_ids", GroupNamesIds)
 	r.HandleFunc("/group/detail", GroupDetail)
 	r.HandleFunc("/group/set", GroupSet)
 	r.HandleFunc("/group/del", GroupDel)

--- a/server/dbdata/group.go
+++ b/server/dbdata/group.go
@@ -32,6 +32,11 @@ type ValData struct {
 	Note   string `json:"note"`
 }
 
+type GroupNameId struct {
+	Id   int    `json:"id"`
+	Name string `json:"name"`
+}
+
 // type Group struct {
 // 	Id               int                    `json:"id" xorm:"pk autoincr not null"`
 // 	Name             string                 `json:"name" xorm:"varchar(60) not null unique"`
@@ -60,6 +65,20 @@ func GetGroupNames() []string {
 	var names []string
 	for _, v := range datas {
 		names = append(names, v.Name)
+	}
+	return names
+}
+
+func GetGroupNamesIds() []GroupNameId {
+	var datas []Group
+	err := Find(&datas, 0, 0)
+	if err != nil {
+		base.Error(err)
+		return nil
+	}
+	var names []GroupNameId
+	for _, v := range datas {
+		names = append(names, GroupNameId{Id: v.Id, Name: v.Name})
 	}
 	return names
 }

--- a/server/dbdata/group_test.go
+++ b/server/dbdata/group_test.go
@@ -63,4 +63,10 @@ func TestGetGroupNames(t *testing.T) {
 	for _, v := range gs {
 		ast.Equal(true, utils.InArrStr(gAll, v))
 	}
+
+	gni := GetGroupNamesIds()
+	for _, v := range gni {
+		ast.NotEqual(0, v.Id)
+		ast.Equal(true, utils.InArrStr(gAll, v.Name))
+	}
 }

--- a/server/dbdata/statsinfo_test.go
+++ b/server/dbdata/statsinfo_test.go
@@ -1,0 +1,55 @@
+package dbdata
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatsInfo(t *testing.T) {
+	ast := assert.New(t)
+
+	preIpData()
+	defer closeIpdata()
+
+	ast.True(StatsInfoIns.ValidAction("online"))
+	ast.False(StatsInfoIns.ValidAction("diskio"))
+	ast.True(StatsInfoIns.ValidScope("30d"))
+	ast.False(StatsInfoIns.ValidScope("60d"))
+
+	up := uint32(100)
+	down := uint32(300)
+	upGroups := map[int]uint32{1: up}
+	downGroups := map[int]uint32{1: down}
+	numGroups := map[int]int{1: 5}
+	// online
+	numData, _ := json.Marshal(numGroups)
+	so := &StatsOnline{Num: 1, NumGroups: string(numData)}
+	// network
+	upData, _ := json.Marshal(upGroups)
+	downData, _ := json.Marshal(downGroups)
+	sn := &StatsNetwork{Up: up, Down: down, UpGroups: string(upData), DownGroups: string(downData)}
+	// cpu
+	sc := &StatsCpu{Percent: 0.3}
+	// mem
+	sm := &StatsMem{Percent: 24.50}
+
+	StatsInfoIns.SetRealTime("online", so)
+	StatsInfoIns.GetRealTime("online")
+	StatsInfoIns.SaveStatsInfo(so, sn, sc, sm)
+
+	var err error
+	_, err = StatsInfoIns.GetData("online", "1h")
+	ast.Nil(err)
+
+	_, err = StatsInfoIns.GetData("network", "1h")
+	ast.Nil(err)
+
+	_, err = StatsInfoIns.GetData("cpu", "1h")
+	ast.Nil(err)
+
+	_, err = StatsInfoIns.GetData("mem", "1h")
+	ast.Nil(err)
+
+}

--- a/server/sessdata/statsinfo.go
+++ b/server/sessdata/statsinfo.go
@@ -22,9 +22,9 @@ func saveStatsInfo() {
 		for range tick.C {
 			up := uint32(0)
 			down := uint32(0)
-			upGroups := make(map[string]uint32)
-			downGroups := make(map[string]uint32)
-			numGroups := make(map[string]int)
+			upGroups := make(map[int]uint32)
+			downGroups := make(map[int]uint32)
+			numGroups := make(map[int]int)
 			onlineNum := 0
 			sessMux.Lock()
 			for _, v := range sessions {
@@ -32,12 +32,16 @@ func saveStatsInfo() {
 				if v.IsActive {
 					// 在线人数
 					onlineNum += 1
-					numGroups[v.Group] += 1
+					numGroups[v.CSess.Group.Id] += 1
 					// 网络吞吐
 					userUp := atomic.LoadUint32(&v.CSess.BandwidthUpPeriod)
 					userDown := atomic.LoadUint32(&v.CSess.BandwidthDownPeriod)
-					upGroups[v.Group] += userUp
-					downGroups[v.Group] += userDown
+					if userUp > 0 {
+						upGroups[v.CSess.Group.Id] += userUp
+					}
+					if userDown > 0 {
+						downGroups[v.CSess.Group.Id] += userDown
+					}
 					up += userUp
 					down += userDown
 				}


### PR DESCRIPTION
首页图表功能已开发完成，本次修改如下：
1、RT
2、优化用户组的图表存储方式，采用id值，节省硬盘空间；
3、增加图表的单元测试
<img width="1261" alt="image" src="https://user-images.githubusercontent.com/3632406/190892806-33b25b28-a6cb-4fd2-91ce-5aa5b6395283.png">
