### PR TITLE
优化邮件配置页面-密码为空时则不修改

### DIFF
--- a/server/admin/api_other.go
+++ b/server/admin/api_other.go
@@ -16,6 +16,11 @@ func setOtherGet(data interface{}, w http.ResponseWriter) {
 		RespError(w, RespInternalErr, err)
 		return
 	}
+	// 不明文输出SMTP的密码
+	switch dbdata.StructName(data) {
+	case "SettingSmtp":
+		data.(*dbdata.SettingSmtp).Password = ""
+	}
 	RespSucess(w, data)
 }
 
@@ -34,7 +39,15 @@ func setOtherEdit(data interface{}, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// fmt.Println(data)
-
+	switch dbdata.StructName(data) {
+	case "SettingSmtp":
+		// 密码为空时则不修改
+		smtp := &dbdata.SettingSmtp{}
+		err := dbdata.SettingGet(smtp)
+		if err == nil && data.(*dbdata.SettingSmtp).Password == "" {
+			data.(*dbdata.SettingSmtp).Password = smtp.Password
+		}
+	}
 	err = dbdata.SettingSet(data)
 	if err != nil {
 		RespError(w, RespInternalErr, err)

--- a/web/src/pages/set/Other.vue
+++ b/web/src/pages/set/Other.vue
@@ -13,7 +13,7 @@
             <el-input v-model="dataSmtp.username"></el-input>
           </el-form-item>
           <el-form-item label="密码" prop="password">
-            <el-input v-model="dataSmtp.password"></el-input>
+            <el-input type="password" v-model="dataSmtp.password" placeholder="密码为空则不修改"></el-input>
           </el-form-item>
           <el-form-item label="加密类型" prop="encryption">
             <el-radio-group v-model="dataSmtp.encryption">


### PR DESCRIPTION
RT，解决多人共用admin账号时，可以查看邮箱密码的问题 #153 

<img width="673" alt="image" src="https://user-images.githubusercontent.com/3632406/196020317-96c37e84-0bc7-44f1-9041-19d793f4b17d.png">

