### PR TITLE
修复node版本过高，Docker编译失败的问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # web
-FROM node:lts-alpine as builder_node
+FROM node:16.17.1-alpine3.15 as builder_node
 WORKDIR /web
 COPY ./web /web
 RUN yarn install \


### PR DESCRIPTION
修复以下问题：
``` bash
 => ERROR [builder_node 4/4] RUN yarn install     && yarn run build     && ls /web/ui                                                                                                                                                   81.5s
 => [builder_golang 2/7] WORKDIR /anylink                                                                                                                                                                                                0.2s
 => [builder_golang 3/7] COPY . /anylink                                                                                                                                                                                                 0.1s
------
 > [builder_node 4/4] RUN yarn install     && yarn run build     && ls /web/ui:
#18 0.509 yarn install v1.22.19
#18 0.650 [1/4] Resolving packages...
#18 1.397 [2/4] Fetching packages...
#18 81.02 error @achrinza/node-ipc@9.2.2: The engine "node" is incompatible with this module. Expected version "8 || 10 || 12 || 14 || 16 || 17". Got "18.12.0"
#18 81.04 error Found incompatible module.
#18 81.04 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
------
executor failed running [/bin/sh -c yarn install     && yarn run build     && ls /web/ui]: exit code: 1

```