### PR TITLE
优化 os 和 userAgent 判断顺序，预留 AnyLink Agent

### DIFF
--- a/server/dbdata/user_act_log.go
+++ b/server/dbdata/user_act_log.go
@@ -41,17 +41,18 @@ var (
 			UserLogout:      "用户登出",
 		},
 		OsOps: []string{ // 操作系统
-			0: "Windows",
-			1: "macOS",
-			2: "Linux",
-			3: "Android",
-			4: "iOS",
-			5: "Unknown",
+			0: "Unknown",
+			1: "Windows",
+			2: "macOS",
+			3: "Linux",
+			4: "Android",
+			5: "iOS",
 		},
 		ClientOps: []string{ // 客户端
-			0: "AnyConnect",
-			1: "OpenConnect",
-			2: "Unknown",
+			0: "Unknown",
+			1: "AnyConnect",
+			2: "OpenConnect",
+			3: "AnyLink",
 		},
 		InfoOps: []string{ // 信息
 			UserLogoutLose:    "用户掉线",
@@ -119,27 +120,29 @@ func (ua *UserActLogProcess) GetInfoOpsById(id uint8) string {
 func (ua *UserActLogProcess) ParseUserAgent(userAgent string) (os_idx, client_idx uint8, ver string) {
 	// Unknown
 	if len(userAgent) == 0 {
-		return 5, 2, ""
+		return 0, 0, ""
 	}
 	// OS
-	os_idx = 5
+	os_idx = 0
 	if strings.Contains(userAgent, "windows") {
-		os_idx = 0
-	} else if strings.Contains(userAgent, "mac os") || strings.Contains(userAgent, "darwin_i386") {
 		os_idx = 1
-	} else if strings.Contains(userAgent, "darwin_arm") || strings.Contains(userAgent, "apple") {
-		os_idx = 4
-	} else if strings.Contains(userAgent, "android") {
-		os_idx = 3
-	} else if strings.Contains(userAgent, "linux") {
+	} else if strings.Contains(userAgent, "mac os") || strings.Contains(userAgent, "darwin_i386") {
 		os_idx = 2
+	} else if strings.Contains(userAgent, "darwin_arm") || strings.Contains(userAgent, "apple") {
+		os_idx = 5
+	} else if strings.Contains(userAgent, "android") {
+		os_idx = 4
+	} else if strings.Contains(userAgent, "linux") {
+		os_idx = 3
 	}
 	// Client
-	client_idx = 2
+	client_idx = 0
 	if strings.Contains(userAgent, "anyconnect") {
-		client_idx = 0
-	} else if strings.Contains(userAgent, "openconnect") {
 		client_idx = 1
+	} else if strings.Contains(userAgent, "openconnect") {
+		client_idx = 2
+	} else if strings.Contains(userAgent, "anylink") {
+		client_idx = 3
 	}
 	// Verion
 	uaSlice := strings.Split(userAgent, " ")

--- a/server/dbdata/user_act_log_test.go
+++ b/server/dbdata/user_act_log_test.go
@@ -19,47 +19,47 @@ func TestParseUserAgent(t *testing.T) {
 		{
 			name: "mac os 1",
 			args: args{userAgent: "cisco anyconnect vpn agent for mac os x 4.10.05085"},
-			want: res{os_idx: 1, client_idx: 0, ver: "4.10.05085"},
+			want: res{os_idx: 2, client_idx: 1, ver: "4.10.05085"},
 		},
 		{
 			name: "mac os 2",
 			args: args{userAgent: "anyconnect darwin_i386 4.10.05085"},
-			want: res{os_idx: 1, client_idx: 0, ver: "4.10.05085"},
+			want: res{os_idx: 2, client_idx: 1, ver: "4.10.05085"},
 		},
 		{
 			name: "windows",
 			args: args{userAgent: "cisco anyconnect vpn agent for windows 4.8.02042"},
-			want: res{os_idx: 0, client_idx: 0, ver: "4.8.02042"},
+			want: res{os_idx: 1, client_idx: 1, ver: "4.8.02042"},
 		},
 		{
 			name: "iPad",
 			args: args{userAgent: "anyconnect applesslvpn_darwin_arm (ipad) 4.10.04060"},
-			want: res{os_idx: 4, client_idx: 0, ver: "4.10.04060"},
+			want: res{os_idx: 5, client_idx: 1, ver: "4.10.04060"},
 		},
 		{
 			name: "iPhone",
 			args: args{userAgent: "cisco anyconnect vpn agent for apple iphone 4.10.04060"},
-			want: res{os_idx: 4, client_idx: 0, ver: "4.10.04060"},
+			want: res{os_idx: 5, client_idx: 1, ver: "4.10.04060"},
 		},
 		{
 			name: "android",
 			args: args{userAgent: "anyconnect android 4.10.05096"},
-			want: res{os_idx: 3, client_idx: 0, ver: "4.10.05096"},
+			want: res{os_idx: 4, client_idx: 1, ver: "4.10.05096"},
 		},
 		{
 			name: "linux",
 			args: args{userAgent: "cisco anyconnect vpn agent for linux v7.08"},
-			want: res{os_idx: 2, client_idx: 0, ver: "7.08"},
+			want: res{os_idx: 3, client_idx: 1, ver: "7.08"},
 		},
 		{
 			name: "openconnect",
 			args: args{userAgent: "openconnect-gui 1.5.3 v7.08"},
-			want: res{os_idx: 5, client_idx: 1, ver: "7.08"},
+			want: res{os_idx: 0, client_idx: 2, ver: "7.08"},
 		},
 		{
 			name: "unknown",
 			args: args{userAgent: "unknown 1.4.3 aabcd"},
-			want: res{os_idx: 5, client_idx: 2, ver: ""},
+			want: res{os_idx: 0, client_idx: 0, ver: ""},
 		},
 	}
 	for _, tt := range tests {

--- a/server/go.sum
+++ b/server/go.sum
@@ -1057,5 +1057,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
 xorm.io/builder v0.3.9 h1:Sd65/LdWyO7LR8+Cbd+e7mm3sK/7U9k0jS3999IDHMc=
 xorm.io/builder v0.3.9/go.mod h1:aUW0S9eb9VCaPohFCH3j7czOx1PMW3i1HrSzbLYGBSE=
-xorm.io/xorm v1.2.2 h1:FFBOEvJ++8fYBA9cywf2sxDVmFktl1SpJzTAG1ab06Y=
-xorm.io/xorm v1.2.2/go.mod h1:fTG8tSjk6O1BYxwuohZUK+S1glnRycsCF05L1qQyEU0=
+xorm.io/xorm v1.2.5 h1:tqN7OhN8P9xi52qBb76I8m5maAJMz/SSbgK2RGPCPbo=
+xorm.io/xorm v1.2.5/go.mod h1:fTG8tSjk6O1BYxwuohZUK+S1glnRycsCF05L1qQyEU0=


### PR DESCRIPTION
把 Unknown 放在最后导致没法扩展支持更多的操作系统和客户端，应该把 Unknown 作为第一个，后续增加其它操作系统或客户端只需要追加即可，另外预留 AnyLink 字符串

```
0: "Windows",
1: "macOS",
2: "Linux",
3: "Android",
4: "iOS",
5: "Unknown",
```
变为
```
0: "Unknown",
1: "Windows",
2: "macOS",
3: "Linux",
4: "Android",
5: "iOS",
```

```
0: "AnyConnect",
1: "OpenConnect",
2: "Unknown",
```
变为
```
0: "Unknown",
1: "AnyConnect",
2: "OpenConnect",
3: "AnyLink",
```