### PR TITLE
新增后台测试登录的功能

### DIFF
--- a/server/admin/api_group.go
+++ b/server/admin/api_group.go
@@ -118,3 +118,30 @@ func GroupDel(w http.ResponseWriter, r *http.Request) {
 	}
 	RespSucess(w, nil)
 }
+
+func GroupAuthLogin(w http.ResponseWriter, r *http.Request) {
+	type AuthLoginData struct {
+		Name string                 `json:"name"`
+		Pwd  string                 `json:"pwd"`
+		Auth map[string]interface{} `json:"auth"`
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		RespError(w, RespInternalErr, err)
+		return
+	}
+	defer r.Body.Close()
+	v := &AuthLoginData{}
+	err = json.Unmarshal(body, &v)
+	if err != nil {
+		RespError(w, RespInternalErr, err)
+		return
+	}
+	err = dbdata.GroupAuthLogin(v.Name, v.Pwd, v.Auth)
+	if err != nil {
+		RespError(w, RespInternalErr, err)
+		return
+	}
+	RespSucess(w, "ok")
+}

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -71,6 +71,7 @@ func StartAdmin() {
 	r.HandleFunc("/group/detail", GroupDetail)
 	r.HandleFunc("/group/set", GroupSet)
 	r.HandleFunc("/group/del", GroupDel)
+	r.HandleFunc("/group/auth_login", GroupAuthLogin)
 
 	r.HandleFunc("/statsinfo/list", StatsInfoList)
 

--- a/server/dbdata/group.go
+++ b/server/dbdata/group.go
@@ -225,6 +225,21 @@ func SetGroup(g *Group) error {
 	return err
 }
 
+func GroupAuthLogin(name, pwd string, authData map[string]interface{}) error {
+	g := &Group{Auth: authData}
+	authType := g.Auth["type"].(string)
+	if _, ok := authRegistry[authType]; !ok {
+		return errors.New("未知的认证方式: " + authType)
+	}
+	auth := makeInstance(authType).(IUserAuth)
+	err := auth.checkData(g.Auth)
+	if err != nil {
+		return err
+	}
+	err = auth.checkUser(name, pwd, g)
+	return err
+}
+
 func parseIpNet(s string) (string, *net.IPNet, error) {
 	ip, ipNet, err := net.ParseCIDR(s)
 	if err != nil {

--- a/server/dbdata/group_test.go
+++ b/server/dbdata/group_test.go
@@ -46,13 +46,14 @@ func TestGetGroupNames(t *testing.T) {
 	authData = map[string]interface{}{
 		"type": "ldap",
 		"ldap": map[string]interface{}{
-			"addr":        "192.168.8.12:389",
-			"tls":         true,
-			"bind_name":   "userfind@abc.com",
-			"bind_pwd":    "afdbfdsafds",
-			"base_dn":     "dc=abc,dc=com",
-			"search_attr": "sAMAccountName",
-			"member_of":   "cn=vpn,cn=user,dc=abc,dc=com",
+			"addr":         "192.168.8.12:389",
+			"tls":          true,
+			"bind_name":    "userfind@abc.com",
+			"bind_pwd":     "afdbfdsafds",
+			"base_dn":      "dc=abc,dc=com",
+			"object_class": "person",
+			"search_attr":  "sAMAccountName",
+			"member_of":    "cn=vpn,cn=user,dc=abc,dc=com",
 		},
 	}
 	g7 := Group{Name: "g7", ClientDns: []ValData{{Val: "114.114.114.114"}}, Auth: authData}

--- a/server/dbdata/user_test.go
+++ b/server/dbdata/user_test.go
@@ -70,13 +70,14 @@ func TestCheckUser(t *testing.T) {
 	authData = map[string]interface{}{
 		"type": "ldap",
 		"ldap": map[string]interface{}{
-			"addr":        "192.168.8.12:389",
-			"tls":         true,
-			"bind_name":   "userfind@abc.com",
-			"bind_pwd":    "afdbfdsafds",
-			"base_dn":     "dc=abc,dc=com",
-			"search_attr": "sAMAccountName",
-			"member_of":   "cn=vpn,cn=user,dc=abc,dc=com",
+			"addr":         "192.168.8.12:389",
+			"tls":          true,
+			"bind_name":    "userfind@abc.com",
+			"bind_pwd":     "afdbfdsafds",
+			"base_dn":      "dc=abc,dc=com",
+			"object_class": "person",
+			"search_attr":  "sAMAccountName",
+			"member_of":    "cn=vpn,cn=user,dc=abc,dc=com",
 		},
 	}
 	g3 := Group{Name: group3, Status: 1, ClientDns: dns, RouteInclude: route, Auth: authData}

--- a/web/src/pages/Home.vue
+++ b/web/src/pages/Home.vue
@@ -230,6 +230,9 @@ export default {
                 case "mem": this.formatMem(data); break;
             }
         }).catch(error => {
+            if (error.response.status === 401) {
+               return ;
+            }            
             this.$message.error('哦，请求出错');
             console.log(error);
         });

--- a/web/src/pages/group/List.vue
+++ b/web/src/pages/group/List.vue
@@ -377,6 +377,7 @@
         title="测试用户登录"
         :visible.sync="authLoginDialog"
         width="600px"
+        custom-class="valgin-dialog"
         center>
         <el-form :model="authLoginForm" :rules="authLoginRules" ref="authLoginForm" label-width="100px">
             <el-form-item label="账号" prop="name">
@@ -389,6 +390,7 @@
                 <el-button type="primary" @click="testAuthLogin()" :loading="authLoginLoading">登录</el-button>
                 <el-button @click="authLoginDialog = false">取 消</el-button>
             </el-form-item>
+        </el-form>
     </el-dialog> 
   </div>
 </template>
@@ -681,5 +683,21 @@ export default {
 
 .el-select {
   width: 80px;
+}
+
+::v-deep .valgin-dialog{
+    display: flex;
+    flex-direction: column;
+    margin:0 !important;
+    position:absolute;
+    top:50%;
+    left:50%;
+    transform:translate(-50%,-50%);
+    max-height:calc(100% - 30px);
+    max-width:calc(100% - 30px);
+}
+::v-deep  .valgin-dialog .el-dialog__body{
+    flex:1;
+    overflow: auto;
 }
 </style>

--- a/web/src/pages/group/List.vue
+++ b/web/src/pages/group/List.vue
@@ -251,7 +251,7 @@
                   <el-form-item label="开启TLS" prop="auth.ldap.tls">
                     <el-switch v-model="ruleForm.auth.ldap.tls"></el-switch>                      
                   </el-form-item>
-                  <el-form-item label="管理员账号" prop="auth.ldap.bind_name" :rules="this.ruleForm.auth.type== 'ldap' ? this.rules['auth.ldap.bind_name'] : [{ required: false }]">
+                  <el-form-item label="管理员 DN" prop="auth.ldap.bind_name" :rules="this.ruleForm.auth.type== 'ldap' ? this.rules['auth.ldap.bind_name'] : [{ required: false }]">
                     <el-input v-model="ruleForm.auth.ldap.bind_name" placeholder="例如 CN=bindadmin,DC=abc,DC=COM"></el-input>
                   </el-form-item>
                   <el-form-item label="管理员密码" prop="auth.ldap.bind_pwd" :rules="this.ruleForm.auth.type== 'ldap' ? this.rules['auth.ldap.bind_pwd'] : [{ required: false }]">
@@ -259,9 +259,12 @@
                   </el-form-item>                                                
                   <el-form-item label="Base DN" prop="auth.ldap.base_dn" :rules="this.ruleForm.auth.type== 'ldap' ? this.rules['auth.ldap.base_dn'] : [{ required: false }]">
                     <el-input v-model="ruleForm.auth.ldap.base_dn" placeholder="例如 DC=abc,DC=com"></el-input>
-                  </el-form-item>  
+                  </el-form-item>
+                  <el-form-item label="用户对象类" prop="auth.ldap.object_class" :rules="this.ruleForm.auth.type== 'ldap' ? this.rules['auth.ldap.object_class'] : [{ required: false }]">
+                    <el-input v-model="ruleForm.auth.ldap.object_class" placeholder="例如 person / user / posixAccount"></el-input>
+                  </el-form-item>                  
                   <el-form-item label="用户唯一ID" prop="auth.ldap.search_attr" :rules="this.ruleForm.auth.type== 'ldap' ? this.rules['auth.ldap.search_attr'] : [{ required: false }]">
-                    <el-input v-model="ruleForm.auth.ldap.search_attr" placeholder="例如 sAMAccountName 或 uid"></el-input>
+                    <el-input v-model="ruleForm.auth.ldap.search_attr" placeholder="例如 sAMAccountName / uid / cn"></el-input>
                   </el-form-item>    
                   <el-form-item label="受限用户组" prop="auth.ldap.member_of">
                     <el-input v-model="ruleForm.auth.ldap.member_of" placeholder="选填, 只允许指定组登入, 例如 CN=HomeWork,DC=abc,DC=com"></el-input>
@@ -359,13 +362,34 @@
                 </el-form-item>
             </el-tab-pane>
             <el-form-item>
-            <el-button type="primary" @click="submitForm('ruleForm')">保存</el-button>
-            <el-button @click="closeDialog">取消</el-button>
+                <templete v-if="activeTab == 'authtype' && ruleForm.auth.type != 'local'">
+                    <el-button @click="openAuthLoginDialog()" style="margin-right:10px">测试登录</el-button>
+                </templete>
+                <el-button type="primary" @click="submitForm('ruleForm')">保存</el-button>
+                <el-button @click="closeDialog">取消</el-button>
             </el-form-item>
           </el-tabs>
         </el-form> 
     </el-dialog>
-
+    <!--测试用户登录弹出框-->
+    <el-dialog
+        :close-on-click-modal="false"
+        title="测试用户登录"
+        :visible.sync="authLoginDialog"
+        width="600px"
+        center>
+        <el-form :model="authLoginForm" :rules="authLoginRules" ref="authLoginForm" label-width="100px">
+            <el-form-item label="账号" prop="name">
+                <el-input v-model="authLoginForm.name" ref="authLoginFormName" @keydown.enter.native="testAuthLogin"></el-input>
+            </el-form-item>
+            <el-form-item label="密码" prop="pwd">
+                <el-input type="password" v-model="authLoginForm.pwd" @keydown.enter.native="testAuthLogin"></el-input>
+            </el-form-item>
+            <el-form-item>
+                <el-button type="primary" @click="testAuthLogin()" :loading="authLoginLoading">登录</el-button>
+                <el-button @click="authLoginDialog = false">取 消</el-button>
+            </el-form-item>
+    </el-dialog> 
   </div>
 </template>
 
@@ -399,6 +423,7 @@ export default {
                       addr:"", 
                       tls:false,
                       base_dn:"",
+                      object_class:"person",
                       search_attr:"sAMAccountName",
                       member_of:"",
                       bind_name:"",
@@ -415,6 +440,21 @@ export default {
         link_acl: [],
         auth : {},
       },
+      authLoginDialog : false,
+      authLoginLoading : false,
+      authLoginForm : {
+        name : "",
+        pwd : "",
+      },   
+      authLoginRules: {
+        name: [
+          {required: true, message: '请输入账号', trigger: 'blur'},
+        ],
+        pwd: [
+          {required: true, message: '请输入密码', trigger: 'blur'},
+          {min: 6, message: '长度至少 6 个字符', trigger: 'blur'}
+        ],
+      },         
       rules: {
         name: [
           {required: true, message: '请输入组名', trigger: 'blur'},
@@ -437,7 +477,7 @@ export default {
           {required: true, message: '请输入服务器地址(含端口)', trigger: 'blur'}
         ],  
         "auth.ldap.bind_name": [
-          {required: true, message: '请输入管理员账号', trigger: 'blur'}
+          {required: true, message: '请输入管理员 DN', trigger: 'blur'}
         ],
         "auth.ldap.bind_pwd": [
           {required: true, message: '请输入管理员密码', trigger: 'blur'}
@@ -445,6 +485,9 @@ export default {
         "auth.ldap.base_dn": [
           {required: true, message: '请输入Base DN值', trigger: 'blur'}
         ],
+        "auth.ldap.object_class": [
+          {required: true, message: '请输入用户对象类', trigger: 'blur'}
+        ],        
         "auth.ldap.search_attr": [
           {required: true, message: '请输入用户唯一ID', trigger: 'blur'}
         ],                                       
@@ -546,6 +589,44 @@ export default {
         }).catch(error => {
           this.$message.error('哦，请求出错');
           console.log(error);
+        });
+      });
+    },
+    testAuthLogin() {
+        this.$refs["authLoginForm"].validate((valid) => {
+            if (!valid) {
+                console.log('error submit!!');
+                return false;
+            }        
+            this.authLoginLoading = true;
+            axios.post('/group/auth_login', {name:this.authLoginForm.name,
+                                            pwd:this.authLoginForm.pwd,
+                                            auth:this.ruleForm.auth}).then(resp => {
+            const rdata = resp.data;
+            if (rdata.code === 0) {
+                this.$message.success("登录成功");
+            } else {
+                this.$message.error(rdata.msg);
+                this.authLoginLoading = false;
+            }
+            console.log(rdata);
+            }).catch(error => {
+            this.$message.error('哦，请求出错');
+            console.log(error);
+            this.authLoginLoading = false;
+            });
+        });
+    },
+    openAuthLoginDialog() {
+      this.$refs["ruleForm"].validate((valid) => {
+        if (!valid) {
+          console.log('error submit!!');
+          return false;
+        }        
+        this.authLoginDialog = true;
+        // set authLoginFormName focus
+        this.$nextTick(() => {
+            this.$refs['authLoginFormName'].focus();
         });
       });
     },

--- a/web/src/pages/group/List.vue
+++ b/web/src/pages/group/List.vue
@@ -500,6 +500,9 @@ export default {
         this.ruleForm.auth = JSON.parse(JSON.stringify(this.defAuth));
         return ;
       }
+      if (row.auth.type == "ldap" && ! row.auth.ldap.object_class) {
+        row.auth.ldap.object_class = this.defAuth.ldap.object_class;
+      }      
       this.ruleForm.auth = Object.assign(JSON.parse(JSON.stringify(this.defAuth)), row.auth);
     },
     handleDel(row) {
@@ -602,18 +605,18 @@ export default {
             axios.post('/group/auth_login', {name:this.authLoginForm.name,
                                             pwd:this.authLoginForm.pwd,
                                             auth:this.ruleForm.auth}).then(resp => {
-            const rdata = resp.data;
-            if (rdata.code === 0) {
-                this.$message.success("登录成功");
-            } else {
-                this.$message.error(rdata.msg);
-                this.authLoginLoading = false;
-            }
-            console.log(rdata);
-            }).catch(error => {
-            this.$message.error('哦，请求出错');
-            console.log(error);
-            this.authLoginLoading = false;
+                    const rdata = resp.data;
+                    if (rdata.code === 0) {
+                        this.$message.success("登录成功");
+                    } else {
+                        this.$message.error(rdata.msg);                
+                    }
+                    this.authLoginLoading = false;
+                    console.log(rdata);
+                }).catch(error => {
+                    this.$message.error('哦，请求出错');
+                    console.log(error);
+                    this.authLoginLoading = false;
             });
         });
     },


### PR DESCRIPTION
RT，详情如下：
1、新增测试登录功能(支持Radius、LDAP)
2、新增“用户对象类”配置项，解决 #179 的问题
3、优化前端监控图表的报错逻辑，401时不报错，避免出现图3的问题

<img width="722" alt="image" src="https://user-images.githubusercontent.com/3632406/212251482-a41f5e95-4d09-409f-8ce8-c520149477fc.png">

<img width="548" alt="image" src="https://user-images.githubusercontent.com/3632406/212251399-64b2af16-7330-4fd9-a5ce-be5e480ccc8f.png">

<img width="557" alt="image" src="https://user-images.githubusercontent.com/3632406/212296465-74cdec5c-74ed-4876-a9ca-899d4579fe39.png">


