### PR TITLE
Fix typos found by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ sudo ./anylink
 1. 开启服务器转发
 
 ```shell
-# flie: /etc/sysctl.conf
+# file: /etc/sysctl.conf
 net.ipv4.ip_forward = 1
 
 #执行如下命令

--- a/server/dbdata/user_act_log.go
+++ b/server/dbdata/user_act_log.go
@@ -155,7 +155,7 @@ func (ua *UserActLogProcess) ParseUserAgent(userAgent string) (os_idx, client_id
 	} else if strings.Contains(userAgent, "anylink") {
 		client_idx = 3
 	}
-	// Verion
+	// Version
 	uaSlice := strings.Split(userAgent, " ")
 	ver = uaSlice[len(uaSlice)-1]
 	if ver[0] == 'v' {

--- a/web/src/pages/group/List.vue
+++ b/web/src/pages/group/List.vue
@@ -235,16 +235,16 @@
                         <el-radio label="ldap" border>LDAP</el-radio>
                     </el-radio-group>
                 </el-form-item>   
-                <templete v-if="ruleForm.auth.type == 'radius'">
+                <template v-if="ruleForm.auth.type == 'radius'">
                   <el-form-item label="服务器地址" prop="auth.radius.addr" :rules="this.ruleForm.auth.type== 'radius' ? this.rules['auth.radius.addr'] : [{ required: false }]">
                       <el-input v-model="ruleForm.auth.radius.addr" placeholder="例如 ip:1812"></el-input>
                   </el-form-item>                
                   <el-form-item label="密钥" prop="auth.radius.secret" :rules="this.ruleForm.auth.type== 'radius' ? this.rules['auth.radius.secret'] : [{ required: false }]">
                       <el-input v-model="ruleForm.auth.radius.secret" placeholder=""></el-input>
                   </el-form-item>               
-                </templete>
+                </template>
 
-                <templete v-if="ruleForm.auth.type == 'ldap'">
+                <template v-if="ruleForm.auth.type == 'ldap'">
                   <el-form-item label="服务器地址" prop="auth.ldap.addr" :rules="this.ruleForm.auth.type== 'ldap' ? this.rules['auth.ldap.addr'] : [{ required: false }]">
                       <el-input v-model="ruleForm.auth.ldap.addr" placeholder="例如 ip:389 / 域名:389"></el-input>    
                   </el-form-item> 
@@ -266,7 +266,7 @@
                   <el-form-item label="受限用户组" prop="auth.ldap.member_of">
                     <el-input v-model="ruleForm.auth.ldap.member_of" placeholder="选填, 只允许指定组登入, 例如 CN=HomeWork,DC=abc,DC=com"></el-input>
                   </el-form-item>                                                                      
-                </templete>                 
+                </template>                 
             </el-tab-pane>  
 
             <el-tab-pane label="路由设置" name="route">


### PR DESCRIPTION
Also, is this really supposed to be `templete` instead of `template`?
https://github.com/bjdgyc/anylink/blob/4d15fe286a366916b975722be84d94595d89b5ac/web/src/pages/group/List.vue#L238