### PR TITLE
修复sniNewParser的panic

### DIFF
--- a/server/handler/payload_access_audit.go
+++ b/server/handler/payload_access_audit.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"crypto/md5"
 	"encoding/binary"
+	"runtime/debug"
 	"time"
 
 	"github.com/bjdgyc/anylink/base"
@@ -101,7 +102,12 @@ func logAuditBatch() {
 
 // 解析IP包的数据
 func logAudit(userName string, pl *sessdata.Payload) {
-	defer putPayload(pl)
+	defer func() {
+		putPayload(pl)
+		if err := recover(); err != nil {
+			base.Error("logAudit is panic: ", err, "\n", string(debug.Stack()), "\n", pl.Data)
+		}
+	}()
 
 	if !(pl.LType == sessdata.LTypeIPData && pl.PType == 0x00) {
 		return

--- a/server/handler/payload_tcp_parser.go
+++ b/server/handler/payload_tcp_parser.go
@@ -31,7 +31,7 @@ func onTCP(payload []byte) (uint8, string) {
 func sniNewParser(b []byte) (uint8, string) {
 	if len(b) < 6 || b[0] != 0x16 || b[1] != 0x03 {
 		return acc_proto_tcp, ""
-	}	
+	}
 	rest := b[5:]
 	restLen := len(rest)
 	if restLen == 0 {

--- a/server/handler/payload_tcp_parser.go
+++ b/server/handler/payload_tcp_parser.go
@@ -29,10 +29,7 @@ func onTCP(payload []byte) (uint8, string) {
 }
 
 func sniNewParser(b []byte) (uint8, string) {
-	if len(b) < 2 || b[0] != 0x16 || b[1] != 0x03 {
-		return acc_proto_tcp, ""
-	}
-	if len(b) < 6 {
+	if len(b) < 6 || b[0] != 0x16 || b[1] != 0x03 {
 		return acc_proto_tcp, ""
 	}	
 	rest := b[5:]

--- a/server/handler/payload_tcp_parser.go
+++ b/server/handler/payload_tcp_parser.go
@@ -32,6 +32,9 @@ func sniNewParser(b []byte) (uint8, string) {
 	if len(b) < 2 || b[0] != 0x16 || b[1] != 0x03 {
 		return acc_proto_tcp, ""
 	}
+	if len(b) < 6 {
+		return acc_proto_tcp, ""
+	}	
 	rest := b[5:]
 	restLen := len(rest)
 	if restLen == 0 {


### PR DESCRIPTION
主要提升“日志审计”模块的健壮性，谢谢大佬！

1、防止日志审计的panic影响到主进程。
2、修复sniNewParser的panic:

```
panic: runtime error: slice bounds out of range [5:4]

goroutine 38 [running]:
github.com/bjdgyc/anylink/handler.sniNewParser({0xc008139834?, 0xc01ee9ff20?, 0xc0005b4cd0?})
```