### PR TITLE
遵循 DPD-REQ 协议，修复 OpenConnect DTLS 的 MTU 探测

### DIFF
--- a/server/handler/link_dtls.go
+++ b/server/handler/link_dtls.go
@@ -64,6 +64,7 @@ func LinkDtls(conn net.Conn, cSess *sessdata.ConnSession) {
 		case 0x03: // DPD-REQ
 			// base.Debug("recv DPD-REQ", cSess.IpAddr)
 			pl.PType = 0x04
+			pl.Data = pl.Data[:n]
 			if payloadOutDtls(cSess, dSess, pl) {
 				return
 			}
@@ -149,7 +150,7 @@ func dtlsWrite(conn net.Conn, dSess *sessdata.DtlsSession, cSess *sessdata.ConnS
 			}
 		} else {
 			// 设置头类型
-			pl.Data = append(pl.Data[:0], pl.PType)
+			pl.Data[0] = pl.PType
 		}
 		n, err := conn.Write(pl.Data)
 		if err != nil {


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/draft-mavrogiannopoulos-openconnect-04#name-the-cstp-channel-protocol
> DPD-REQ: used for dead peer detection. Once sent the peer should reply with a DPD-RESP  packet, that has the same contents as the original request.  

openconnect 的 DTLS 根据 DPD-RESP 最终确定 mtu，否则设为最小值。
之前的代码没有遵循上面的描述返回原样内容，导致 openconnect 的 dtls 网速很慢
