### PR TITLE
acl支持逗号分隔多端口号配置

### DIFF
--- a/server/dbdata/group.go
+++ b/server/dbdata/group.go
@@ -164,17 +164,17 @@ func SetGroup(g *Group) error {
 			}
 			v.IpNet = ipNet
 
-			port := ""
+			portsStr := ""
 			switch vp := v.Port.(type) {
 				case float64:
-					port = strconv.Itoa(int(vp))
+					portsStr = strconv.Itoa(int(vp))
 				case string:
-					port = vp
+					portsStr = vp
 			}
 
-			if regexp.MustCompile(`^\d{1,5}(-\d{1,5})?(,\d{1,5}(-\d{1,5})?)*$`).MatchString(port) {
+			if regexp.MustCompile(`^\d{1,5}(-\d{1,5})?(,\d{1,5}(-\d{1,5})?)*$`).MatchString(portsStr) {
 				ports := map[uint16]int8{}
-				for _, p := range strings.Split(port, ",") {
+				for _, p := range strings.Split(portsStr, ",") {
 					if p == "" {
 						continue
 					}
@@ -203,7 +203,7 @@ func SetGroup(g *Group) error {
 				v.Ports = ports
 				linkAcl = append(linkAcl, v)
 			} else {
-				return errors.New("端口: " + port + " 格式错误,请用逗号分隔的端口,比如: 22,80,443 连续端口用-,比如:1234-5678")
+				return errors.New("端口: " + portsStr + " 格式错误,请用逗号分隔的端口,比如: 22,80,443 连续端口用-,比如:1234-5678")
 			}
 
 		}

--- a/server/dbdata/group.go
+++ b/server/dbdata/group.go
@@ -203,7 +203,7 @@ func SetGroup(g *Group) error {
 				v.Ports = ports
 				linkAcl = append(linkAcl, v)
 			} else {
-				return errors.New("端口: "+v.PortStr+" 格式错误,请用逗号分隔的端口列表,比如: 22,80,443")
+				return errors.New("端口: "+v.PortStr+" 格式错误,请用逗号分隔的端口,比如: 22,80,443 连续端口用-,比如:1234-5678")
 			}
 
 		}

--- a/server/dbdata/group.go
+++ b/server/dbdata/group.go
@@ -164,6 +164,7 @@ func SetGroup(g *Group) error {
 			}
 			v.IpNet = ipNet
 			if regexp.MustCompile(`^\d{1,5}(,\d{1,5})*$`).MatchString(v.PortStr) {
+				ports := []uint16{}
 				for _, port := range strings.Split(v.PortStr, ",") {
 					if port == "" {
 						continue
@@ -172,8 +173,9 @@ func SetGroup(g *Group) error {
 					if err != nil {
 						return errors.New("端口:"+port+" 格式错误, " + err.Error())
 					}
-					v.Ports = append(v.Ports, uint16(portInt))
+					ports = append(ports, uint16(portInt))
 				}
+				v.Ports = ports
 				linkAcl = append(linkAcl, v)
 			} else {
 				return errors.New("端口: "+v.PortStr+" 格式错误,请用逗号分隔的端口列表,比如: 22,80,443")

--- a/server/handler/payload.go
+++ b/server/handler/payload.go
@@ -89,7 +89,7 @@ func checkLinkAcl(group *dbdata.Group, pl *sessdata.Payload) bool {
 		// 循环判断ip和端口
 		if v.IpNet.Contains(ipDst) {
 			// 放行允许ip的ping
-			if v.Port == ipPort || v.Port == 0 || ipProto == waterutil.ICMP {
+			if dbdata.ContainsInPorts( v.Ports , ipPort) || v.Ports[0] == 0 || ipProto == waterutil.ICMP {
 				if v.Action == dbdata.Allow {
 					return true
 				} else {

--- a/server/handler/payload.go
+++ b/server/handler/payload.go
@@ -88,9 +88,12 @@ func checkLinkAcl(group *dbdata.Group, pl *sessdata.Payload) bool {
 	for _, v := range group.LinkAcl {
 		// 循环判断ip和端口
 		if v.IpNet.Contains(ipDst) {
+
 			// 放行允许ip的ping
-			if(v.Ports==nil || len(v.Ports)==0){
-				if v.Port==ipPort || v.Port==0 || ipProto == waterutil.ICMP {
+			if v.Ports == nil || len(v.Ports) == 0 {
+				//单端口历史数据兼容
+				port := uint16(v.Port.(float64))
+				if port == ipPort || port == 0 || ipProto == waterutil.ICMP {
 					if v.Action == dbdata.Allow {
 						return true
 					} else {
@@ -98,7 +101,7 @@ func checkLinkAcl(group *dbdata.Group, pl *sessdata.Payload) bool {
 					}
 				}
 			} else {
-				if dbdata.ContainsInPorts( v.Ports , ipPort) || dbdata.ContainsInPorts( v.Ports , 0) || ipProto == waterutil.ICMP {
+				if dbdata.ContainsInPorts(v.Ports, ipPort) || dbdata.ContainsInPorts(v.Ports, 0) || ipProto == waterutil.ICMP {
 					if v.Action == dbdata.Allow {
 						return true
 					} else {

--- a/server/handler/payload.go
+++ b/server/handler/payload.go
@@ -89,11 +89,21 @@ func checkLinkAcl(group *dbdata.Group, pl *sessdata.Payload) bool {
 		// 循环判断ip和端口
 		if v.IpNet.Contains(ipDst) {
 			// 放行允许ip的ping
-			if dbdata.ContainsInPorts( v.Ports , ipPort) || v.Ports[0].PortFrom == 0 || ipProto == waterutil.ICMP {
-				if v.Action == dbdata.Allow {
-					return true
-				} else {
-					return false
+			if(v.Ports==nil || len(v.Ports)==0){
+				if v.Port==ipPort || v.Port==0 || ipProto == waterutil.ICMP {
+					if v.Action == dbdata.Allow {
+						return true
+					} else {
+						return false
+					}
+				}
+			} else {
+				if dbdata.ContainsInPorts( v.Ports , ipPort) || dbdata.ContainsInPorts( v.Ports , 0) || ipProto == waterutil.ICMP {
+					if v.Action == dbdata.Allow {
+						return true
+					} else {
+						return false
+					}
 				}
 			}
 		}

--- a/server/handler/payload.go
+++ b/server/handler/payload.go
@@ -89,7 +89,7 @@ func checkLinkAcl(group *dbdata.Group, pl *sessdata.Payload) bool {
 		// 循环判断ip和端口
 		if v.IpNet.Contains(ipDst) {
 			// 放行允许ip的ping
-			if dbdata.ContainsInPorts( v.Ports , ipPort) || v.Ports[0] == 0 || ipProto == waterutil.ICMP {
+			if dbdata.ContainsInPorts( v.Ports , ipPort) || v.Ports[0].PortFrom == 0 || ipProto == waterutil.ICMP {
 				if v.Action == dbdata.Allow {
 					return true
 				} else {

--- a/web/src/pages/group/List.vue
+++ b/web/src/pages/group/List.vue
@@ -52,7 +52,7 @@
             <template slot-scope="scope">
                 <el-row v-if="scope.row.bandwidth > 0">{{ convertBandwidth(scope.row.bandwidth, 'BYTE', 'Mbps') }} Mbps</el-row>
                 <el-row v-else>不限</el-row>
-            </template>            
+            </template>
         </el-table-column>
 
         <el-table-column
@@ -72,10 +72,10 @@
             <el-row v-for="(item,inx) in scope.row.route_include.slice(0, readMinRows)" :key="inx">{{ item.val }}</el-row>
             <div v-if="scope.row.route_include.length > readMinRows">
               <div v-if="readMore[`ri_${ scope.row.id }`]">
-                <el-row v-for="(item,inx) in scope.row.route_include.slice(readMinRows)" :key="inx">{{ item.val }}</el-row>              
+                <el-row v-for="(item,inx) in scope.row.route_include.slice(readMinRows)" :key="inx">{{ item.val }}</el-row>
               </div>
-              <el-button size="mini" type="text" @click="toggleMore(`ri_${ scope.row.id }`)">{{ readMore[`ri_${ scope.row.id }`] ? "▲ 收起" : "▼ 更多" }}</el-button>              
-            </div>            
+              <el-button size="mini" type="text" @click="toggleMore(`ri_${ scope.row.id }`)">{{ readMore[`ri_${ scope.row.id }`] ? "▲ 收起" : "▼ 更多" }}</el-button>
+            </div>
           </template>
         </el-table-column>
 
@@ -87,9 +87,9 @@
             <el-row v-for="(item,inx) in scope.row.route_exclude.slice(0, readMinRows)" :key="inx">{{ item.val }}</el-row>
             <div v-if="scope.row.route_exclude.length > readMinRows">
               <div v-if="readMore[`re_${ scope.row.id }`]">
-                <el-row v-for="(item,inx) in scope.row.route_exclude.slice(readMinRows)" :key="inx">{{ item.val }}</el-row>              
+                <el-row v-for="(item,inx) in scope.row.route_exclude.slice(readMinRows)" :key="inx">{{ item.val }}</el-row>
               </div>
-              <el-button size="mini" type="text" @click="toggleMore(`re_${ scope.row.id }`)">{{ readMore[`re_${ scope.row.id }`] ? "▲ 收起" : "▼ 更多" }}</el-button>              
+              <el-button size="mini" type="text" @click="toggleMore(`re_${ scope.row.id }`)">{{ readMore[`re_${ scope.row.id }`] ? "▲ 收起" : "▼ 更多" }}</el-button>
             </div>
           </template>
         </el-table-column>
@@ -100,15 +100,15 @@
             min-width="180">
           <template slot-scope="scope">
             <el-row v-for="(item,inx) in scope.row.link_acl.slice(0, readMinRows)" :key="inx">
-              {{ item.action }} => {{ item.val }} : {{ item.port }}
+              {{ item.action }} => {{ item.val }} : {{ item.port_str }}
             </el-row>
             <div v-if="scope.row.link_acl.length > readMinRows">
               <div v-if="readMore[`la_${ scope.row.id }`]">
                 <el-row v-for="(item,inx) in scope.row.link_acl.slice(readMinRows)" :key="inx">
-                  {{ item.action }} => {{ item.val }} : {{ item.port }}
+                  {{ item.action }} => {{ item.val }} : {{ item.port_str }}
                 </el-row>
               </div>
-              <el-button size="mini" type="text" @click="toggleMore(`la_${ scope.row.id }`)">{{ readMore[`la_${ scope.row.id }`] ? "▲ 收起" : "▼ 更多" }}</el-button>              
+              <el-button size="mini" type="text" @click="toggleMore(`la_${ scope.row.id }`)">{{ readMore[`la_${ scope.row.id }`] ? "▲ 收起" : "▼ 更多" }}</el-button>
             </div>
           </template>
         </el-table-column>
@@ -178,7 +178,7 @@
 
       <el-form :model="ruleForm" :rules="rules" ref="ruleForm" label-width="100px" class="ruleForm">
         <el-tabs v-model="activeTab" :before-leave="beforeTabLeave">
-           <el-tab-pane label="通用" name="general">      
+           <el-tab-pane label="通用" name="general">
                 <el-form-item label="用户组ID" prop="id">
                 <el-input v-model="ruleForm.id" disabled></el-input>
                 </el-form-item>
@@ -234,7 +234,7 @@
                         <el-radio :label="1" border>启用</el-radio>
                         <el-radio :label="0" border>停用</el-radio>
                     </el-radio-group>
-                </el-form-item>            
+                </el-form-item>
             </el-tab-pane>
 
             <el-tab-pane label="认证方式" name="authtype">
@@ -244,43 +244,43 @@
                         <el-radio label="radius" border>Radius</el-radio>
                         <el-radio label="ldap" border>LDAP</el-radio>
                     </el-radio-group>
-                </el-form-item>   
+                </el-form-item>
                 <template v-if="ruleForm.auth.type == 'radius'">
                   <el-form-item label="服务器地址" prop="auth.radius.addr" :rules="this.ruleForm.auth.type== 'radius' ? this.rules['auth.radius.addr'] : [{ required: false }]">
                       <el-input v-model="ruleForm.auth.radius.addr" placeholder="例如 ip:1812"></el-input>
-                  </el-form-item>                
+                  </el-form-item>
                   <el-form-item label="密钥" prop="auth.radius.secret" :rules="this.ruleForm.auth.type== 'radius' ? this.rules['auth.radius.secret'] : [{ required: false }]">
                       <el-input v-model="ruleForm.auth.radius.secret" placeholder=""></el-input>
-                  </el-form-item>               
+                  </el-form-item>
                 </template>
 
                 <template v-if="ruleForm.auth.type == 'ldap'">
                   <el-form-item label="服务器地址" prop="auth.ldap.addr" :rules="this.ruleForm.auth.type== 'ldap' ? this.rules['auth.ldap.addr'] : [{ required: false }]">
-                      <el-input v-model="ruleForm.auth.ldap.addr" placeholder="例如 ip:389 / 域名:389"></el-input>    
-                  </el-form-item> 
+                      <el-input v-model="ruleForm.auth.ldap.addr" placeholder="例如 ip:389 / 域名:389"></el-input>
+                  </el-form-item>
                   <el-form-item label="开启TLS" prop="auth.ldap.tls">
-                    <el-switch v-model="ruleForm.auth.ldap.tls"></el-switch>                      
+                    <el-switch v-model="ruleForm.auth.ldap.tls"></el-switch>
                   </el-form-item>
                   <el-form-item label="管理员 DN" prop="auth.ldap.bind_name" :rules="this.ruleForm.auth.type== 'ldap' ? this.rules['auth.ldap.bind_name'] : [{ required: false }]">
                     <el-input v-model="ruleForm.auth.ldap.bind_name" placeholder="例如 CN=bindadmin,DC=abc,DC=COM"></el-input>
                   </el-form-item>
                   <el-form-item label="管理员密码" prop="auth.ldap.bind_pwd" :rules="this.ruleForm.auth.type== 'ldap' ? this.rules['auth.ldap.bind_pwd'] : [{ required: false }]">
                     <el-input type="password" v-model="ruleForm.auth.ldap.bind_pwd" placeholder=""></el-input>
-                  </el-form-item>                                                
+                  </el-form-item>
                   <el-form-item label="Base DN" prop="auth.ldap.base_dn" :rules="this.ruleForm.auth.type== 'ldap' ? this.rules['auth.ldap.base_dn'] : [{ required: false }]">
                     <el-input v-model="ruleForm.auth.ldap.base_dn" placeholder="例如 DC=abc,DC=com"></el-input>
                   </el-form-item>
                   <el-form-item label="用户对象类" prop="auth.ldap.object_class" :rules="this.ruleForm.auth.type== 'ldap' ? this.rules['auth.ldap.object_class'] : [{ required: false }]">
                     <el-input v-model="ruleForm.auth.ldap.object_class" placeholder="例如 person / user / posixAccount"></el-input>
-                  </el-form-item>                  
+                  </el-form-item>
                   <el-form-item label="用户唯一ID" prop="auth.ldap.search_attr" :rules="this.ruleForm.auth.type== 'ldap' ? this.rules['auth.ldap.search_attr'] : [{ required: false }]">
                     <el-input v-model="ruleForm.auth.ldap.search_attr" placeholder="例如 sAMAccountName / uid / cn"></el-input>
                   </el-form-item>
                   <el-form-item label="受限用户组" prop="auth.ldap.member_of">
                     <el-input v-model="ruleForm.auth.ldap.member_of" placeholder="选填, 只允许指定组登入, 例如 CN=HomeWork,DC=abc,DC=com"></el-input>
-                  </el-form-item>                                                                      
-                </template>                 
-            </el-tab-pane>  
+                  </el-form-item>
+                </template>
+            </el-tab-pane>
 
             <el-tab-pane label="路由设置" name="route">
                 <el-form-item label="包含路由" prop="route_include">
@@ -293,7 +293,7 @@
                     <el-col :span="4">
                       <el-button size="mini" type="info" icon="el-icon-edit" circle
                                 @click.prevent="openIpListDialog('route_include')"></el-button>
-                    </el-col>                    
+                    </el-col>
                 </el-row>
                 <templete v-if="activeTab == 'route'">
                     <el-row v-for="(item,index) in ruleForm.route_include"
@@ -322,7 +322,7 @@
                     <el-col :span="4">
                       <el-button size="mini" type="info" icon="el-icon-edit" circle
                                 @click.prevent="openIpListDialog('route_exclude')"></el-button>
-                    </el-col>                    
+                    </el-col>
                 </el-row>
                 <templete v-if="activeTab == 'route'">
                     <el-row v-for="(item,index) in ruleForm.route_exclude"
@@ -344,16 +344,16 @@
             <el-tab-pane label="权限控制" name="link_acl">
                 <el-form-item label="权限控制" prop="link_acl">
                 <el-row class="msg-info">
-                    <el-col :span="20">输入CIDR格式如: 192.168.3.0/24 端口0表示所有端口</el-col>
+                    <el-col :span="20">输入CIDR格式如: 192.168.3.0/24 端口0表示所有端口,多个端口用,号分隔</el-col>
                     <el-col :span="4">
                     <el-button size="mini" type="success" icon="el-icon-plus" circle
                                 @click.prevent="addDomain(ruleForm.link_acl)"></el-button>
                     </el-col>
-                </el-row>  
+                </el-row>
 
                 <el-row v-for="(item,index) in ruleForm.link_acl"
-                        :key="index" style="margin-bottom: 5px" :gutter="5">
-                    <el-col :span="11">
+                        :key="index" style="margin-bottom: 5px" :gutter="1">
+                    <el-col :span="10">
                     <el-input placeholder="请输入CIDR地址" v-model="item.val">
                         <el-select v-model="item.action" slot="prepend">
                         <el-option label="允许" value="allow"></el-option>
@@ -361,10 +361,10 @@
                         </el-select>
                     </el-input>
                     </el-col>
-                    <el-col :span="3">
-                    <el-input v-model.number="item.port" placeholder="端口"></el-input>
+                    <el-col :span="6">
+                    <el-input v-model="item.port_str" type="textarea" :autosize="{ minRows: 1, maxRows: 2}" placeholder="多端口,号分隔"></el-input>
                     </el-col>
-                    <el-col :span="8">
+                    <el-col :span="6">
                     <el-input v-model="item.note" placeholder="备注"></el-input>
                     </el-col>
                     <el-col :span="2">
@@ -378,7 +378,7 @@
             <el-tab-pane label="域名拆分隧道" name="ds_domains">
                 <el-form-item label="包含域名" prop="ds_include_domains">
                     <el-input type="textarea" :rows="5" v-model="ruleForm.ds_include_domains" placeholder="输入域名用,号分隔，默认匹配所有子域名, 如baidu.com,163.com"></el-input>
-                </el-form-item>                
+                </el-form-item>
                 <el-form-item label="排除域名" prop="ds_exclude_domains">
                     <el-input type="textarea" :rows="5" v-model="ruleForm.ds_exclude_domains" placeholder="输入域名用,号分隔，默认匹配所有子域名, 如baidu.com,163.com"></el-input>
                     <div class="msg-info">注：域名拆分隧道，仅支持AnyConnect的windows和MacOS桌面客户端，不支持移动端.</div>
@@ -392,7 +392,7 @@
                 <el-button @click="closeDialog">取消</el-button>
             </el-form-item>
           </el-tabs>
-        </el-form> 
+        </el-form>
     </el-dialog>
     <!--测试用户登录弹出框-->
     <el-dialog
@@ -414,7 +414,7 @@
                 <el-button @click="authLoginDialog = false">取 消</el-button>
             </el-form-item>
         </el-form>
-    </el-dialog> 
+    </el-dialog>
     <!--编辑模式弹窗-->
     <el-dialog
     :close-on-click-modal="false"
@@ -462,10 +462,10 @@ export default {
       readMinRows : 5,
       maxRouteRows : 2500,
       defAuth : {
-                type:'local', 
+                type:'local',
                 radius:{addr:"", secret:""},
                 ldap:{
-                      addr:"", 
+                      addr:"",
                       tls:false,
                       base_dn:"",
                       object_class:"person",
@@ -474,7 +474,7 @@ export default {
                       bind_name:"",
                       bind_pwd:"",
                       },
-      },          
+      },
       ruleForm: {
         bandwidth: 0,
         bandwidth_format: '0',
@@ -488,7 +488,7 @@ export default {
       },
       authLoginDialog : false,
       ipListDialog : false,
-      authLoginLoading : false,      
+      authLoginLoading : false,
       authLoginForm : {
         name : "",
         pwd : "",
@@ -506,7 +506,7 @@ export default {
           {required: true, message: '请输入密码', trigger: 'blur'},
           {min: 6, message: '长度至少 6 个字符', trigger: 'blur'}
         ],
-      },         
+      },
       rules: {
         name: [
           {required: true, message: '请输入组名', trigger: 'blur'},
@@ -524,22 +524,22 @@ export default {
         ],
         "auth.radius.secret": [
           {required: true, message: '请输入Radius密钥', trigger: 'blur'}
-        ],        
+        ],
         "auth.ldap.addr": [
           {required: true, message: '请输入服务器地址(含端口)', trigger: 'blur'}
-        ],  
+        ],
         "auth.ldap.bind_name": [
           {required: true, message: '请输入管理员 DN', trigger: 'blur'}
         ],
         "auth.ldap.bind_pwd": [
           {required: true, message: '请输入管理员密码', trigger: 'blur'}
-        ],         
+        ],
         "auth.ldap.base_dn": [
           {required: true, message: '请输入Base DN值', trigger: 'blur'}
         ],
         "auth.ldap.object_class": [
           {required: true, message: '请输入用户对象类', trigger: 'blur'}
-        ],        
+        ],
         "auth.ldap.search_attr": [
           {required: true, message: '请输入用户唯一ID', trigger: 'blur'}
         ],
@@ -554,7 +554,7 @@ export default {
       }
       if (row.auth.type == "ldap" && ! row.auth.ldap.object_class) {
         row.auth.ldap.object_class = this.defAuth.ldap.object_class;
-      }      
+      }
       this.ruleForm.auth = Object.assign(JSON.parse(JSON.stringify(this.defAuth)), row.auth);
     },
     handleDel(row) {
@@ -572,9 +572,9 @@ export default {
         console.log(error);
       });
     },
-    handleEdit(row) {      
+    handleEdit(row) {
       !this.$refs['ruleForm'] || this.$refs['ruleForm'].resetFields();
-      console.log(row)      
+      console.log(row)
       this.user_edit_dialog = true
       if (!row) {
         this.setAuthData(row)
@@ -586,7 +586,7 @@ export default {
         }
       }).then(resp => {
         resp.data.data.bandwidth_format = this.convertBandwidth(resp.data.data.bandwidth, 'BYTE', 'Mbps').toString();
-        this.ruleForm = resp.data.data;        
+        this.ruleForm = resp.data.data;
         this.setAuthData(resp.data.data);
       }).catch(error => {
         this.$message.error('哦，请求出错');
@@ -654,7 +654,7 @@ export default {
             if (!valid) {
                 console.log('error submit!!');
                 return false;
-            }        
+            }
             this.authLoginLoading = true;
             axios.post('/group/auth_login', {name:this.authLoginForm.name,
                                             pwd:this.authLoginForm.pwd,
@@ -663,7 +663,7 @@ export default {
                     if (rdata.code === 0) {
                         this.$message.success("登录成功");
                     } else {
-                        this.$message.error(rdata.msg);                
+                        this.$message.error(rdata.msg);
                     }
                     this.authLoginLoading = false;
                     console.log(rdata);
@@ -679,7 +679,7 @@ export default {
         if (!valid) {
           console.log('error submit!!');
           return false;
-        }        
+        }
         this.authLoginDialog = true;
         // set authLoginFormName focus
         this.$nextTick(() => {
@@ -690,14 +690,14 @@ export default {
     openIpListDialog(type) {
       this.ipListDialog = true;
       this.ipEditForm.type = type;
-      this.ipEditForm.ip_list = this.ruleForm[type].map(item => item.val + (item.note ? "," + item.note : "")).join("\n");      
+      this.ipEditForm.ip_list = this.ruleForm[type].map(item => item.val + (item.note ? "," + item.note : "")).join("\n");
     },
     ipEdit() {
         this.ipEditLoading = true;
         let ipList = [];
         if (this.ipEditForm.ip_list.trim() !== "") {
             ipList = this.ipEditForm.ip_list.trim().split("\n");
-        }        
+        }
         let arr = [];
         for (let i = 0; i < ipList.length; i++) {
           let item = ipList[i];
@@ -714,7 +714,7 @@ export default {
           };
           if (this.ipEditForm.type == "route_include" && ip[0] == "all") {
             pushToArr();
-            continue;  
+            continue;
           }
           let valid = this.isValidCIDR(ip[0]);
           if (!valid.valid) {
@@ -768,14 +768,14 @@ export default {
       var isSwitch = true
       if (! this.user_edit_dialog) {
         return isSwitch;
-      }      
+      }
       this.$refs['ruleForm'].validate((valid) => {
         if (!valid) {
           this.$message.error("错误：您有必填项没有填写。")
           isSwitch = false;
           return false;
         }
-      });      
+      });
       return isSwitch;
     },
     closeDialog() {

--- a/web/src/pages/group/List.vue
+++ b/web/src/pages/group/List.vue
@@ -362,7 +362,7 @@
                     </el-input>
                     </el-col>
                     <el-col :span="6">
-                    <el-input v-model="item.port_str" type="textarea" :autosize="{ minRows: 1, maxRows: 2}" placeholder="多端口,号分隔"></el-input>
+                    <el-input type="textarea" :autosize="{ minRows: 1, maxRows: 2}" v-model="item.port_str"  placeholder="多端口,号分隔"></el-input>
                     </el-col>
                     <el-col :span="6">
                     <el-input v-model="item.note" placeholder="备注"></el-input>

--- a/web/src/pages/group/List.vue
+++ b/web/src/pages/group/List.vue
@@ -344,8 +344,8 @@
             <el-tab-pane label="权限控制" name="link_acl">
                 <el-form-item label="权限控制" prop="link_acl">
                 <el-row class="msg-info">
-                    <el-col :span="20">输入CIDR格式如: 192.168.3.0/24 端口0表示所有端口,多个端口用,号分隔</el-col>
-                    <el-col :span="4">
+                    <el-col :span="22">输入CIDR格式如: 192.168.3.0/24 端口0表示所有端口,多个端口用,号分隔,连续端口:1234-5678</el-col>
+                    <el-col :span="2">
                     <el-button size="mini" type="success" icon="el-icon-plus" circle
                                 @click.prevent="addDomain(ruleForm.link_acl)"></el-button>
                     </el-col>

--- a/web/src/pages/group/List.vue
+++ b/web/src/pages/group/List.vue
@@ -100,12 +100,12 @@
             min-width="180">
           <template slot-scope="scope">
             <el-row v-for="(item,inx) in scope.row.link_acl.slice(0, readMinRows)" :key="inx">
-              {{ item.action }} => {{ item.val }} : {{ item.port_str }}
+              {{ item.action }} => {{ item.val }} : {{ item.port }}
             </el-row>
             <div v-if="scope.row.link_acl.length > readMinRows">
               <div v-if="readMore[`la_${ scope.row.id }`]">
                 <el-row v-for="(item,inx) in scope.row.link_acl.slice(readMinRows)" :key="inx">
-                  {{ item.action }} => {{ item.val }} : {{ item.port_str }}
+                  {{ item.action }} => {{ item.val }} : {{ item.port }}
                 </el-row>
               </div>
               <el-button size="mini" type="text" @click="toggleMore(`la_${ scope.row.id }`)">{{ readMore[`la_${ scope.row.id }`] ? "▲ 收起" : "▼ 更多" }}</el-button>
@@ -362,7 +362,7 @@
                     </el-input>
                     </el-col>
                     <el-col :span="6">
-                    <el-input type="textarea" :autosize="{ minRows: 1, maxRows: 2}" v-model="item.port_str"  placeholder="多端口,号分隔"></el-input>
+                    <el-input type="textarea" :autosize="{ minRows: 1, maxRows: 2}" v-model="item.port"  placeholder="多端口,号分隔"></el-input>
                     </el-col>
                     <el-col :span="6">
                     <el-input v-model="item.note" placeholder="备注"></el-input>


### PR DESCRIPTION
如题,支持多端口逗号分隔,连续端口-连接,比如:
22,80,443,1234-5678
<img width="798" alt="image" src="https://github.com/bjdgyc/anylink/assets/4082111/9507c8ff-6911-49d8-8425-83da762f7fa8">

<img width="1610" alt="image" src="https://github.com/bjdgyc/anylink/assets/4082111/a97abeb7-ea81-4229-ac0e-aa7c7f124ec1">
